### PR TITLE
ci(release): migrate to npm trusted publishing with oidc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release:
@@ -29,6 +30,7 @@ jobs:
         with:
           node-version: 18
           cache: "pnpm"
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
@@ -49,4 +51,3 @@ jobs:
           title: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- add id-token: write permission for oidc authentication
- configure setup-node with registry-url for automatic oidc
- remove NPM_TOKEN secret dependency from workflow

this enables npm trusted publishing, eliminating the need for long-lived tokens and providing automatic provenance for releases.