### PR TITLE
docs: update generateImage import to non-experimental

### DIFF
--- a/.changeset/update-experimental-imports.md
+++ b/.changeset/update-experimental-imports.md
@@ -1,0 +1,6 @@
+---
+"@runpod/ai-sdk-provider": patch
+---
+
+docs: update generateImage and generateSpeech imports to non-experimental
+

--- a/README.md
+++ b/README.md
@@ -207,13 +207,13 @@ With image models you can:
 - **Text-to-image**: generate a new image from a text prompt.
 - **Edit image**: transform an existing image by providing reference image(s).
 
-All examples use the AI SDK's `experimental_generateImage` and `runpod.image(modelId)`.
+All examples use the AI SDK's `generateImage` and `runpod.image(modelId)`.
 
 ### Text-to-Image
 
 ```ts
 import { runpod } from '@runpod/ai-sdk-provider';
-import { experimental_generateImage as generateImage } from 'ai';
+import { generateImage } from 'ai';
 import { writeFileSync } from 'fs';
 
 const { image } = await generateImage({
@@ -240,7 +240,7 @@ For editing, pass reference images via `prompt.images` (recommended). The AI SDK
 
 ```ts
 import { runpod } from '@runpod/ai-sdk-provider';
-import { experimental_generateImage as generateImage } from 'ai';
+import { generateImage } from 'ai';
 
 const { image } = await generateImage({
   model: runpod.image('pruna/p-image-edit'),
@@ -258,7 +258,7 @@ Note: Prior to v1.0.0, images were passed via `providerOptions.runpod.image` / `
 
 ```ts
 import { runpod } from '@runpod/ai-sdk-provider';
-import { experimental_generateImage as generateImage } from 'ai';
+import { generateImage } from 'ai';
 
 const { image } = await generateImage({
   model: runpod.image('google/nano-banana-pro-edit'),
@@ -376,11 +376,11 @@ Supported model: `google/nano-banana-pro-edit`
 
 ## Speech Models
 
-Generate speech using the AI SDK's `experimental_generateSpeech` and `runpod.speech(...)`:
+Generate speech using the AI SDK's `generateSpeech` and `runpod.speech(...)`:
 
 ```ts
 import { runpod } from '@runpod/ai-sdk-provider';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 
 const result = await generateSpeech({
   model: runpod.speech('resembleai/chatterbox-turbo'),

--- a/docs/image_models.md
+++ b/docs/image_models.md
@@ -20,7 +20,7 @@ This document lists supported Runpod image models and their capabilities. Follow
 
 ```ts
 import { runpod } from '@runpod/ai-sdk-provider';
-import { experimental_generateImage as generateImage } from 'ai';
+import { generateImage } from 'ai';
 
 const { image } = await generateImage({
   model: runpod.imageModel('nano-banana-edit'),

--- a/docs/planning/002_image.md
+++ b/docs/planning/002_image.md
@@ -65,7 +65,7 @@ Extend the Runpod AI SDK Provider to support image generation using Runpod's tex
 
   ```typescript
   import { runpod } from '@runpod/ai-sdk-provider';
-  import { experimental_generateImage as generateImage } from 'ai';
+  import { generateImage } from 'ai';
 
   const { image } = await generateImage({
     model: runpod.image('qwen/qwen-image'),
@@ -100,7 +100,7 @@ The final implementation should support these usage patterns:
 
 ```typescript
 import { runpod } from '@runpod/ai-sdk-provider';
-import { experimental_generateImage as generateImage } from 'ai';
+import { generateImage } from 'ai';
 
 // Basic image generation
 const { image } = await generateImage({
@@ -173,7 +173,7 @@ const { image } = await generateImage({
 ## Success Metrics
 
 - [ ] Package supports both text and image generation seamlessly
-- [ ] `experimental_generateImage()` function works with Runpod models
+- [ ] `generateImage()` function works with Runpod models
 - [ ] Image generation parameters are properly validated and passed through
 - [ ] Generated images are returned in correct base64 format
 - [ ] All existing functionality remains unaffected
@@ -195,7 +195,7 @@ const { image } = await generateImage({
 
 ## Definition of Done
 
-- Developer can generate images using `experimental_generateImage()` with Runpod models
+- Developer can generate images using `generateImage()` with Runpod models
 - All image generation parameters work correctly
 - Tests pass and documentation includes image generation examples
 - Package maintains backward compatibility with existing text generation features


### PR DESCRIPTION
Update documentation to use `import { generateImage } from 'ai'` instead of the deprecated `experimental_generateImage` alias.

The AI SDK now exports `generateImage` as the official import (not experimental anymore).