### PR TITLE
feat(image): accept aiApiId as valid model ID

### DIFF
--- a/.changeset/accept-ai-api-id.md
+++ b/.changeset/accept-ai-api-id.md
@@ -1,0 +1,9 @@
+---
+'@runpod/ai-sdk-provider': minor
+---
+
+Accept aiApiId (endpoint ID) as a valid model ID for image models and add video generation support.
+
+Image models now use the same fallback pattern as speech, transcription, and video models: any unrecognized model ID is used directly as `https://api.runpod.ai/v2/{modelId}` instead of incorrectly appending `/openai/v1`. This means aiApiIds like `wan-2-6-t2i` or `black-forest-labs-flux-1-schnell` work out of the box without needing explicit mappings. Console endpoint URLs are also now supported for image models.
+
+Video generation support includes 15 models across multiple providers (Pruna, Vidu, Kling, Wan, Seedance, Sora) with async polling, provider options, and both text-to-video and image-to-video capabilities.

--- a/src/runpod-image-model.test.ts
+++ b/src/runpod-image-model.test.ts
@@ -1156,6 +1156,132 @@ describe('RunpodImageModel', () => {
     });
   });
 
+  describe('aiApiId format support', () => {
+    it('should build correct payload for WAN model with aiApiId format', () => {
+      const wanModel = new RunpodImageModel('wan-2-6-t2i', {
+        provider: 'runpod',
+        baseURL: 'https://api.runpod.ai/v2/wan-2-6-t2i',
+        headers: () => ({ Authorization: 'Bearer test-key' }),
+        fetch: mockFetch,
+      });
+
+      const payload = (wanModel as any).buildInputPayload(
+        'A tea shop',
+        '1280*1280',
+        42,
+        {}
+      );
+
+      expect(payload).toMatchObject({
+        prompt: 'A tea shop',
+        size: '1280*1280',
+        seed: 42,
+      });
+      // WAN model should not have negative_prompt
+      expect(payload.negative_prompt).toBeUndefined();
+    });
+
+    it('should build correct payload for Flux model with aiApiId format', () => {
+      const fluxModel = new RunpodImageModel(
+        'black-forest-labs-flux-1-schnell',
+        {
+          provider: 'runpod',
+          baseURL: 'https://api.runpod.ai/v2/black-forest-labs-flux-1-schnell',
+          headers: () => ({ Authorization: 'Bearer test-key' }),
+          fetch: mockFetch,
+        }
+      );
+
+      const payload = (fluxModel as any).buildInputPayload(
+        'Test prompt',
+        '1024*768',
+        42,
+        {}
+      );
+
+      expect(payload).toMatchObject({
+        prompt: 'Test prompt',
+        width: 1024,
+        height: 768,
+        seed: 42,
+        num_inference_steps: 4,
+        image_format: 'png',
+      });
+    });
+
+    it('should build correct payload for Z-Image Turbo with aiApiId format', () => {
+      const zImageModel = new RunpodImageModel('z-image-turbo', {
+        provider: 'runpod',
+        baseURL: 'https://api.runpod.ai/v2/z-image-turbo',
+        headers: () => ({ Authorization: 'Bearer test-key' }),
+        fetch: mockFetch,
+      });
+
+      const payload = (zImageModel as any).buildInputPayload(
+        'Test prompt',
+        '1024*1024',
+        42,
+        {}
+      );
+
+      expect(payload).toMatchObject({
+        prompt: 'Test prompt',
+        size: '1024*1024',
+        seed: 42,
+        output_format: 'png',
+        enable_safety_checker: true,
+      });
+    });
+
+    it('should use Z-Image Turbo size validation with aiApiId format', async () => {
+      const zImageModel = new RunpodImageModel('z-image-turbo', {
+        provider: 'runpod',
+        baseURL: 'https://api.runpod.ai/v2/z-image-turbo',
+        headers: () => ({ Authorization: 'Bearer test-key' }),
+        fetch: mockFetch,
+      });
+
+      // 2048x2048 is not in Z-Image Turbo's supported sizes
+      await expect(
+        zImageModel.doGenerate({
+          prompt: 'Test',
+          n: 1,
+          size: '2048x2048',
+          aspectRatio: undefined,
+          seed: undefined,
+          providerOptions: {},
+          headers: {},
+          abortSignal: undefined,
+        })
+      ).rejects.toThrow(InvalidArgumentError);
+    });
+
+    it('should build correct payload for Qwen Image Edit 2511 with aiApiId format', () => {
+      const qwenModel = new RunpodImageModel('qwen-image-edit-2511', {
+        provider: 'runpod',
+        baseURL: 'https://api.runpod.ai/v2/qwen-image-edit-2511',
+        headers: () => ({ Authorization: 'Bearer test-key' }),
+        fetch: mockFetch,
+      });
+
+      const payload = (qwenModel as any).buildInputPayload(
+        'Edit this',
+        '1024*1024',
+        42,
+        {},
+        '1:1',
+        ['https://example.com/input.jpg']
+      );
+
+      expect(payload).toMatchObject({
+        prompt: 'Edit this',
+        size: '1024*1024',
+        seed: 42,
+        images: ['https://example.com/input.jpg'],
+      });
+    });
+  });
+
   describe('FAILED status handling', () => {
     it('should throw error with actual error message when status is FAILED', async () => {
       // This simulates an actual Runpod API error response (e.g., invalid size for WAN 2.6)
@@ -1167,7 +1293,8 @@ describe('RunpodImageModel', () => {
               status: 'FAILED',
               delayTime: 3383,
               executionTime: 4651,
-              error: 'Total pixels (262144) must be between 589824 and 2073600.',
+              error:
+                'Total pixels (262144) must be between 589824 and 2073600.',
               output: { status: 'failed' },
             }),
             { headers: { 'content-type': 'application/json' } }

--- a/src/runpod-image-model.ts
+++ b/src/runpod-image-model.ts
@@ -145,7 +145,10 @@ function validateWanSize(size: string): boolean {
     });
   }
 
-  if (aspectRatio < WAN_MIN_ASPECT_RATIO || aspectRatio > WAN_MAX_ASPECT_RATIO) {
+  if (
+    aspectRatio < WAN_MIN_ASPECT_RATIO ||
+    aspectRatio > WAN_MAX_ASPECT_RATIO
+  ) {
     throw new InvalidArgumentError({
       argument: 'size',
       message: `Size ${size} has aspect ratio ${aspectRatio.toFixed(2)}, which is outside the valid range for WAN 2.6 (1:4 to 4:1).`,
@@ -651,8 +654,7 @@ export class RunpodImageModel implements ImageModelV3 {
         output_format: (runpodOptions?.output_format as string) ?? 'jpeg',
         enable_base64_output:
           (runpodOptions?.enable_base64_output as boolean) ?? false,
-        enable_sync_mode:
-          (runpodOptions?.enable_sync_mode as boolean) ?? false,
+        enable_sync_mode: (runpodOptions?.enable_sync_mode as boolean) ?? false,
       };
 
       // Use standardized files if provided, otherwise use providerOptions.images
@@ -697,8 +699,7 @@ export class RunpodImageModel implements ImageModelV3 {
         output_format: (runpodOptions?.output_format as string) ?? 'jpeg',
         enable_base64_output:
           (runpodOptions?.enable_base64_output as boolean) ?? false,
-        enable_sync_mode:
-          (runpodOptions?.enable_sync_mode as boolean) ?? false,
+        enable_sync_mode: (runpodOptions?.enable_sync_mode as boolean) ?? false,
         ...runpodOptions,
       };
 

--- a/src/runpod-provider.test.ts
+++ b/src/runpod-provider.test.ts
@@ -148,9 +148,22 @@ describe('RunpodProvider', () => {
       const model = provider.imageModel('my-custom/image-model' as any);
       expect(model).toBeInstanceOf(RunpodImageModel);
 
-      // Verify the model was created with derived endpoint
+      // Verify the model was created with derived endpoint (no /openai/v1 for image models)
       expect((RunpodImageModel as any).mock.calls[0][1].baseURL).toBe(
-        'https://api.runpod.ai/v2/my-custom-image-model/openai/v1'
+        'https://api.runpod.ai/v2/my-custom/image-model'
+      );
+    });
+
+    it('should accept a Runpod Console endpoint URL for image models', () => {
+      const provider = createRunpod();
+      const url =
+        'https://console.runpod.io/serverless/user/endpoint/uhyz0hnkemrk6r';
+
+      provider.imageModel(url);
+
+      expect((RunpodImageModel as any).mock.calls[0][0]).toBe('uhyz0hnkemrk6r');
+      expect((RunpodImageModel as any).mock.calls[0][1].baseURL).toBe(
+        'https://api.runpod.ai/v2/uhyz0hnkemrk6r'
       );
     });
   });
@@ -437,6 +450,92 @@ describe('RunpodProvider', () => {
       const model = provider.video(modelId);
 
       expect(model).toBeInstanceOf(RunpodVideoModel);
+    });
+  });
+
+  describe('aiApiId resolution (endpoint IDs used directly)', () => {
+    it('should derive correct endpoint for chat model aiApiIds via fallback', () => {
+      const provider = createRunpod();
+
+      // aiApiIds have no slashes, so deriveEndpointURL just appends /openai/v1
+      provider.chatModel('qwen3-32b-awq');
+
+      const call = OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      // Model name is passed through as-is (no mapping needed)
+      expect(call[0]).toBe('qwen3-32b-awq');
+      expect(call[1].url({ path: '/chat/completions' })).toBe(
+        'https://api.runpod.ai/v2/qwen3-32b-awq/openai/v1/chat/completions'
+      );
+    });
+
+    it('should derive correct endpoint for image model aiApiIds via fallback', () => {
+      const provider = createRunpod();
+
+      const aiApiIds = [
+        'seedream-3-0-t2i',
+        'wan-2-6-t2i',
+        'qwen-image-t2i',
+        'black-forest-labs-flux-1-schnell',
+      ];
+
+      for (const aiApiId of aiApiIds) {
+        vi.clearAllMocks();
+        provider.imageModel(aiApiId);
+
+        expect((RunpodImageModel as any).mock.calls[0][0]).toBe(aiApiId);
+        expect((RunpodImageModel as any).mock.calls[0][1].baseURL).toBe(
+          `https://api.runpod.ai/v2/${aiApiId}`
+        );
+      }
+    });
+
+    it('should derive correct endpoint for speech model aiApiIds via fallback', () => {
+      const provider = createRunpod();
+
+      provider.speechModel('chatterbox-turbo');
+
+      expect((RunpodSpeechModel as any).mock.calls[0][0]).toBe(
+        'chatterbox-turbo'
+      );
+      // Falls through to fallback since 'chatterbox-turbo' is not in the mapping
+      // (only 'resembleai/chatterbox-turbo' is) — produces the same URL
+      expect((RunpodSpeechModel as any).mock.calls[0][1].baseURL).toBe(
+        'https://api.runpod.ai/v2/chatterbox-turbo'
+      );
+    });
+
+    it('should derive correct endpoint for transcription model aiApiIds via fallback', () => {
+      const provider = createRunpod();
+
+      provider.transcriptionModel('whisper-v3-large');
+
+      expect((RunpodTranscriptionModel as any).mock.calls[0][0]).toBe(
+        'whisper-v3-large'
+      );
+      expect((RunpodTranscriptionModel as any).mock.calls[0][1].baseURL).toBe(
+        'https://api.runpod.ai/v2/whisper-v3-large'
+      );
+    });
+
+    it('should derive correct endpoint for video model aiApiIds via fallback', () => {
+      const provider = createRunpod();
+
+      const aiApiIds = [
+        'p-video',
+        'wan-2-6-t2v',
+        'seedance-v1-5-pro-i2v',
+        'sora-2-pro-i2v',
+      ];
+
+      for (const aiApiId of aiApiIds) {
+        vi.clearAllMocks();
+        provider.videoModel(aiApiId);
+
+        expect((RunpodVideoModel as any).mock.calls[0][0]).toBe(aiApiId);
+        expect((RunpodVideoModel as any).mock.calls[0][1].baseURL).toBe(
+          `https://api.runpod.ai/v2/${aiApiId}`
+        );
+      }
     });
   });
 });

--- a/src/runpod-provider.ts
+++ b/src/runpod-provider.ts
@@ -291,17 +291,20 @@ export function createRunpod(
   };
 
   const createImageModel = (modelId: string) => {
-    let baseURL: string;
+    const endpointIdFromConsole = parseRunpodConsoleEndpointId(modelId);
+    const normalizedModelId = endpointIdFromConsole ?? modelId;
 
-    if (options.baseURL) {
-      baseURL = options.baseURL;
-    } else {
-      // Use hardcoded mapping if available, otherwise derive endpoint
-      baseURL =
-        IMAGE_MODEL_ID_TO_ENDPOINT_URL[modelId] || deriveEndpointURL(modelId);
-    }
+    // Prefer explicit mapping for known image model IDs.
+    const mappedBaseURL = IMAGE_MODEL_ID_TO_ENDPOINT_URL[normalizedModelId];
 
-    return new RunpodImageModel(modelId, {
+    const baseURL =
+      options.baseURL ??
+      mappedBaseURL ??
+      (normalizedModelId.startsWith('http')
+        ? normalizedModelId
+        : `https://api.runpod.ai/v2/${normalizedModelId}`);
+
+    return new RunpodImageModel(normalizedModelId, {
       provider: 'runpod.image',
       baseURL,
       headers: getHeaders,


### PR DESCRIPTION
## Summary

- Fix `createImageModel` to use the same fallback pattern as speech, transcription, and video models — unrecognized model IDs now resolve to `https://api.runpod.ai/v2/{modelId}` instead of incorrectly appending `/openai/v1`
- Add `parseRunpodConsoleEndpointId` support for image models (Console URLs now work)
- Add changeset covering both this fix and the video generation feature from #57

Closes #59
Related: DR-1281

## How it works

The mappings only exist for `org/model` format IDs where the endpoint URL can't be trivially derived. Any other ID (aiApiId, custom endpoint ID, etc.) falls through to the `https://api.runpod.ai/v2/${modelId}` fallback — no explicit mapping needed. If the endpoint doesn't exist, the API returns an error.

## Test plan

- [x] `pnpm test` — 117 tests pass (node + edge)
- [x] `pnpm type-check` — no errors
- [x] `pnpm lint` — no new warnings
- [x] New tests verify aiApiId fallback resolution for chat, image, speech, transcription, and video models
- [x] New tests verify image model payload construction with aiApiId format (WAN, Flux, Z-Image Turbo, Qwen Edit)
- [x] New test verifies Console URL support for image models