### PR TITLE
feat(image): add google/nano-banana-2-edit image model

### DIFF
--- a/.changeset/add-nano-banana-2-edit.md
+++ b/.changeset/add-nano-banana-2-edit.md
@@ -1,0 +1,5 @@
+---
+'@runpod/ai-sdk-provider': minor
+---
+
+Add support for the google/nano-banana-2-edit image model with resolution options (1k/2k/4k), 14 aspect ratios, output format, and safety checker.

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ Check out our [examples](https://github.com/runpod/examples/tree/main/ai-sdk/get
 | `pruna/p-image-edit`                   | edit | up to 1440x1440   | 1:1, 16:9, 9:16, 4:3, 3:4, 3:2, 2:3             |
 | `google/nano-banana-edit`              | edit | up to 4096x4096   | 1:1, 4:3, 3:4                                   |
 | `google/nano-banana-pro-edit`          | edit | 1k, 2k, 4k        | 1:1, 16:9, 9:16, 4:3, 3:4, 3:2, 2:3, 21:9       |
+| `google/nano-banana-2-edit`           | edit | 1k, 2k, 4k        | 1:1, 3:2, 2:3, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9, 1:4, 4:1, 1:8, 8:1 |
 | `bytedance/seedream-3.0`               | t2i  | up to 4096x4096   | 1:1, 4:3, 3:4                                   |
 | `bytedance/seedream-4.0`               | t2i  | up to 4096x4096   | 1:1, 4:3, 3:4                                   |
 | `bytedance/seedream-4.0-edit`          | edit | up to 4096x4096   | uses size                                       |

--- a/src/runpod-image-model.test.ts
+++ b/src/runpod-image-model.test.ts
@@ -654,6 +654,105 @@ describe('RunpodImageModel', () => {
       expect(payload).not.toHaveProperty('seed');
     });
 
+    it('should build correct payload for Nano Banana 2 edit', () => {
+      const nanoBanana2Model = new RunpodImageModel(
+        'google/nano-banana-2-edit',
+        {
+          provider: 'runpod',
+          baseURL: 'https://api.runpod.ai/v2/google-nano-banana-2-edit',
+          headers: () => ({ Authorization: 'Bearer test-key' }),
+          fetch: mockFetch,
+        }
+      );
+
+      const images = [
+        'https://example.com/img1.jpg',
+        'https://example.com/img2.jpg',
+      ];
+
+      const payload = (nanoBanana2Model as any).buildInputPayload(
+        'Edit these images together',
+        '1:1',
+        undefined,
+        {
+          images,
+          resolution: '2k',
+          output_format: 'png',
+          enable_safety_checker: false,
+        }
+      );
+
+      expect(payload).toMatchObject({
+        prompt: 'Edit these images together',
+        aspect_ratio: '1:1',
+        resolution: '2k',
+        output_format: 'png',
+        enable_safety_checker: false,
+        images,
+      });
+      expect(payload).not.toHaveProperty('size');
+      expect(payload).not.toHaveProperty('seed');
+    });
+
+    it('should build correct payload for Nano Banana 2 edit with defaults', () => {
+      const nanoBanana2Model = new RunpodImageModel(
+        'google/nano-banana-2-edit',
+        {
+          provider: 'runpod',
+          baseURL: 'https://api.runpod.ai/v2/google-nano-banana-2-edit',
+          headers: () => ({ Authorization: 'Bearer test-key' }),
+          fetch: mockFetch,
+        }
+      );
+
+      const payload = (nanoBanana2Model as any).buildInputPayload(
+        'A futuristic cityscape',
+        '1:1',
+        undefined,
+        {}
+      );
+
+      expect(payload).toMatchObject({
+        prompt: 'A futuristic cityscape',
+        aspect_ratio: '1:1',
+        resolution: '1k',
+        output_format: 'jpeg',
+        enable_safety_checker: true,
+      });
+      expect(payload).not.toHaveProperty('images');
+    });
+
+    it('should build correct payload for Nano Banana 2 edit with standardized files', () => {
+      const nanoBanana2Model = new RunpodImageModel(
+        'google/nano-banana-2-edit',
+        {
+          provider: 'runpod',
+          baseURL: 'https://api.runpod.ai/v2/google-nano-banana-2-edit',
+          headers: () => ({ Authorization: 'Bearer test-key' }),
+          fetch: mockFetch,
+        }
+      );
+
+      const standardizedImages = [
+        'https://standard.com/img1.jpg',
+        'https://standard.com/img2.jpg',
+      ];
+
+      const payload = (nanoBanana2Model as any).buildInputPayload(
+        'Combine these',
+        '1:1',
+        undefined,
+        { images: ['https://legacy.com/img1.jpg'] },
+        '16:9',
+        standardizedImages
+      );
+
+      // Standardized files should take precedence over providerOptions.images
+      expect(payload.images).toEqual(standardizedImages);
+      // aspect_ratio from providerOptions not set, so falls back to aspectRatio param
+      expect(payload.aspect_ratio).toBe('16:9');
+    });
+
     it('should build correct payload for Qwen Image Edit 2511', () => {
       const qwenEdit2511Model = new RunpodImageModel(
         'qwen/qwen-image-edit-2511',
@@ -939,6 +1038,75 @@ describe('RunpodImageModel', () => {
       expect(capturedBody?.input?.images).toEqual(inputImages);
       expect(result.images[0]).toEqual(new Uint8Array([9, 8, 7]));
     });
+
+    it('should send Nano Banana 2 edit payload from files', async () => {
+      let capturedBody: any | undefined;
+
+      mockFetch.mockImplementation(async (input: any, init?: any) => {
+        const url = typeof input === 'string' ? input : input?.url;
+
+        if (url?.includes('/runsync')) {
+          capturedBody = JSON.parse(init?.body ?? '{}');
+          return new Response(
+            JSON.stringify({
+              id: 'job-nb2',
+              status: 'COMPLETED',
+              output: { result: 'https://cdn.test/nb2-out.jpg' },
+            }),
+            { headers: { 'content-type': 'application/json' } }
+          );
+        }
+
+        if (url === 'https://cdn.test/nb2-out.jpg') {
+          return new Response(new Uint8Array([4, 5, 6]), {
+            headers: { 'content-type': 'image/jpeg' },
+          });
+        }
+
+        throw new Error(`Unexpected fetch url: ${String(url)}`);
+      });
+
+      const nb2Model = new RunpodImageModel('google/nano-banana-2-edit', {
+        provider: 'runpod',
+        baseURL: 'https://api.runpod.ai/v2/google-nano-banana-2-edit',
+        headers: () => ({ Authorization: 'Bearer test-key' }),
+        fetch: mockFetch,
+      });
+
+      const inputImages = [
+        'https://example.com/img1.jpg',
+        'https://example.com/img2.jpg',
+      ];
+
+      const result = await nb2Model.doGenerate({
+        prompt: 'Combine these images',
+        n: 1,
+        size: undefined,
+        aspectRatio: '16:9',
+        seed: undefined,
+        files: promptImagesToFiles(inputImages),
+        mask: undefined,
+        providerOptions: {
+          runpod: {
+            resolution: '4k',
+            output_format: 'png',
+            enable_safety_checker: false,
+          },
+        } as any,
+        headers: {},
+        abortSignal: undefined,
+      });
+
+      expect(capturedBody?.input).toMatchObject({
+        prompt: 'Combine these images',
+        aspect_ratio: '16:9',
+        resolution: '4k',
+        output_format: 'png',
+        enable_safety_checker: false,
+        images: inputImages,
+      });
+      expect(result.images[0]).toEqual(new Uint8Array([4, 5, 6]));
+    });
   });
 
   describe('files parameter (from prompt.images)', () => {
@@ -1167,7 +1335,8 @@ describe('RunpodImageModel', () => {
               status: 'FAILED',
               delayTime: 3383,
               executionTime: 4651,
-              error: 'Total pixels (262144) must be between 589824 and 2073600.',
+              error:
+                'Total pixels (262144) must be between 589824 and 2073600.',
               output: { status: 'failed' },
             }),
             { headers: { 'content-type': 'application/json' } }

--- a/src/runpod-image-model.ts
+++ b/src/runpod-image-model.ts
@@ -145,7 +145,10 @@ function validateWanSize(size: string): boolean {
     });
   }
 
-  if (aspectRatio < WAN_MIN_ASPECT_RATIO || aspectRatio > WAN_MAX_ASPECT_RATIO) {
+  if (
+    aspectRatio < WAN_MIN_ASPECT_RATIO ||
+    aspectRatio > WAN_MAX_ASPECT_RATIO
+  ) {
     throw new InvalidArgumentError({
       argument: 'size',
       message: `Size ${size} has aspect ratio ${aspectRatio.toFixed(2)}, which is outside the valid range for WAN 2.6 (1:4 to 4:1).`,
@@ -202,13 +205,16 @@ export class RunpodImageModel implements ImageModelV3 {
     // Check if this is a Nano Banana Pro model (skip standard size/aspectRatio validation)
     const isNanoBananaProModel = this.modelId.includes('nano-banana-pro');
 
+    // Check if this is a Nano Banana 2 model (skip standard size/aspectRatio validation)
+    const isNanoBanana2Model = this.modelId.includes('nano-banana-2');
+
     // Check if this is a WAN model (uses WAN-specific pixel/aspect ratio constraints)
     const isWanModel = this.modelId.includes('wan-2');
 
     // Determine the size to use
     let runpodSize: string;
 
-    if (isPrunaModel || isNanoBananaProModel) {
+    if (isPrunaModel || isNanoBananaProModel || isNanoBanana2Model) {
       // These models use aspect_ratio string directly, skip size validation
       // Pass through the aspectRatio or use default, validation happens at API level
       runpodSize = aspectRatio || '1:1';
@@ -636,6 +642,33 @@ export class RunpodImageModel implements ImageModelV3 {
       }
     }
 
+    // Check if this is a Nano Banana 2 model (google/nano-banana-2-edit)
+    const isNanoBanana2Model = this.modelId.includes('nano-banana-2');
+    if (isNanoBanana2Model) {
+      // Nano Banana 2 image edit
+      // Supported aspect_ratio: "1:1", "3:2", "2:3", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9", "1:4", "4:1", "1:8", "8:1"
+      // Supported resolution: "1k", "2k", "4k"
+      // Supported output_format: "jpeg", "png"
+      const nanoBanana2Payload: Record<string, unknown> = {
+        prompt,
+        aspect_ratio:
+          (runpodOptions?.aspect_ratio as string) ?? aspectRatio ?? '1:1',
+        resolution: (runpodOptions?.resolution as string) ?? '1k',
+        output_format: (runpodOptions?.output_format as string) ?? 'jpeg',
+        enable_safety_checker:
+          (runpodOptions?.enable_safety_checker as boolean) ?? true,
+      };
+
+      // Use standardized files if provided, otherwise use providerOptions.images
+      if (standardizedImages && standardizedImages.length > 0) {
+        nanoBanana2Payload.images = standardizedImages;
+      } else if (runpodOptions?.images) {
+        nanoBanana2Payload.images = runpodOptions.images;
+      }
+
+      return nanoBanana2Payload;
+    }
+
     // Check if this is a Nano Banana Pro model (google/nano-banana-pro-edit)
     const isNanaBananaProModel = this.modelId.includes('nano-banana-pro');
     if (isNanaBananaProModel) {
@@ -651,8 +684,7 @@ export class RunpodImageModel implements ImageModelV3 {
         output_format: (runpodOptions?.output_format as string) ?? 'jpeg',
         enable_base64_output:
           (runpodOptions?.enable_base64_output as boolean) ?? false,
-        enable_sync_mode:
-          (runpodOptions?.enable_sync_mode as boolean) ?? false,
+        enable_sync_mode: (runpodOptions?.enable_sync_mode as boolean) ?? false,
       };
 
       // Use standardized files if provided, otherwise use providerOptions.images
@@ -697,8 +729,7 @@ export class RunpodImageModel implements ImageModelV3 {
         output_format: (runpodOptions?.output_format as string) ?? 'jpeg',
         enable_base64_output:
           (runpodOptions?.enable_base64_output as boolean) ?? false,
-        enable_sync_mode:
-          (runpodOptions?.enable_sync_mode as boolean) ?? false,
+        enable_sync_mode: (runpodOptions?.enable_sync_mode as boolean) ?? false,
         ...runpodOptions,
       };
 

--- a/src/runpod-image-options.ts
+++ b/src/runpod-image-options.ts
@@ -14,4 +14,6 @@ export type RunpodImageModelId =
   | 'tongyi-mai/z-image-turbo'
   // Nano Banana (edit only)
   | 'google/nano-banana-edit'
-  | 'nano-banana-edit'; // backwards compatibility
+  | 'nano-banana-edit' // backwards compatibility
+  // Nano Banana 2 (edit only)
+  | 'google/nano-banana-2-edit';

--- a/src/runpod-provider.ts
+++ b/src/runpod-provider.ts
@@ -140,6 +140,9 @@ const IMAGE_MODEL_ID_TO_ENDPOINT_URL: Record<string, string> = {
   // Nano Banana (edit only)
   'google/nano-banana-edit': 'https://api.runpod.ai/v2/nano-banana-edit',
   'nano-banana-edit': 'https://api.runpod.ai/v2/nano-banana-edit', // backwards compatibility
+  // Nano Banana 2 (edit only)
+  'google/nano-banana-2-edit':
+    'https://api.runpod.ai/v2/google-nano-banana-2-edit',
   // Nano Banana Pro (edit only)
   'google/nano-banana-pro-edit':
     'https://api.runpod.ai/v2/nano-banana-pro-edit',


### PR DESCRIPTION
## Summary
- Add `google/nano-banana-2-edit` image edit model with resolution options (1k/2k/4k), 14 aspect ratios, output format (jpeg/png), safety checker, and multi-image input
- Add endpoint mapping, model ID type, payload builder, and 4 new tests

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes (no new warnings)
- [x] `pnpm prettier-check` passes
- [x] All 47 image model tests pass (node + edge)
- [ ] Manual verification with live Runpod endpoint